### PR TITLE
#172700078-Fix broken form input

### DIFF
--- a/__tests__/components/resetPassword/modifyPasswordForm.test.js
+++ b/__tests__/components/resetPassword/modifyPasswordForm.test.js
@@ -28,6 +28,6 @@ describe('Change passwordForm', () => {
     await act(async () => {
       wrapper.find('button#submitBtn').simulate('click');
     });
-    expect(wrapper.find('input#confirmPassword').props().value).toEqual('');
+    expect(wrapper.find('input#confirm').props().value).toEqual('');
   });
 });

--- a/__tests__/components/resetPassword/modifyPasswordPage.test.js
+++ b/__tests__/components/resetPassword/modifyPasswordPage.test.js
@@ -24,11 +24,11 @@ describe('Test modify password', () => {
       </Provider>,
     );
     const newPassword = wrapper.find('input#newPassword');
-    const confirm = wrapper.find('input#confirmPassword');
+    const confirm = wrapper.find('input#confirm');
     newPassword.simulate('change', { target: { name: 'newPassword', value: 'eugene2@gmail' } });
     confirm.simulate('change', { target: { name: 'confirmPassword', value: 'eugene2@gmail' } });
     expect(wrapper.find('input#newPassword').props().value).toEqual('eugene2@gmail');
-    expect(wrapper.find('input#confirmPassword').props().value).toEqual('eugene2@gmail');
+    expect(wrapper.find('input#confirm').props().value).toEqual('eugene2@gmail');
     expect(wrapper.props().store.getState()).toEqual({ user: { message: 'hello' } });
 
   });

--- a/src/components/resetPassword/ModifyPasswordForm.js
+++ b/src/components/resetPassword/ModifyPasswordForm.js
@@ -66,7 +66,7 @@ const PasswordReset = ({
         palceholder="Confirm password"
         onchenge={inputChanging}
         type="password"
-        id="confirmPassword"
+        id="confirm"
       />
       <ButtonElememnt
         id="submitBtn"

--- a/src/views/Landing.js
+++ b/src/views/Landing.js
@@ -12,7 +12,7 @@ const Landing = () => (
         savvy members of staff, by leveraging the modern web.
       </p>
       <ul>
-        <Link to="/login" id="getStartedBtn">
+        <Link to="/signup" id="getStartedBtn">
           GET STARTED NOW
         </Link>
       </ul>

--- a/src/views/Signup.js
+++ b/src/views/Signup.js
@@ -198,7 +198,7 @@ class Signup extends Component {
             label="SIGN UP"
             className="btn"
           ></Button>
-          <a id="forgotPassword" href="#">
+          <a id="forgotPassword" href="/login">
             <p>Already have an account? Login here</p>
           </a>
         </Form>


### PR DESCRIPTION
#### What does this PR do?
- put form inputs  in order 
#### Description of Task to be completed?
- to re-organize reset password form input that was broken due to the css  conflict
#### How should this be manually tested?
- opening your terminal and run this command `git clone https://github.com/Stackup-Rwanda/knights-bn-frontend.git` 
- run `cd knights-bn-frontend folder`
 - run `git fetch && git checkout ft-reset-password-170947604` 
- run `npm install` and then run `npm run dev-start`
- past this URL `http://localhost:8080/password/reset` in your browser and see how the form is designed
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
#### Screenshots (if appropriate)
<img width="448" alt="Screen Shot 2020-05-06 at 17 27 02" src="https://user-images.githubusercontent.com/36619897/81207562-077eb200-8fce-11ea-8b4e-11e5a1a65512.png">

<img width="1017" alt="Screen Shot 2020-05-06 at 18 36 05" src="https://user-images.githubusercontent.com/36619897/81203822-ad2f2280-8fc8-11ea-82e3-a7cd04ecdea8.png">

#### Questions:

